### PR TITLE
SMTP_SECURE documentation

### DIFF
--- a/docs/self-hosting/development.md
+++ b/docs/self-hosting/development.md
@@ -31,7 +31,7 @@ Make sure you have `pnpm` installed `npm install -g pnpm`.
 $ git clone https://github.com/docmost/docmost
 $ cd docmost
 $ pnpm install
-$ cp .env.exmaple .env
+$ cp .env.example .env
 ```
 
 Make sure to update the .env file.  

--- a/docs/self-hosting/environment-variables.md
+++ b/docs/self-hosting/environment-variables.md
@@ -57,6 +57,7 @@ To configure your application, set the following environment variables. These va
 | `SMTP_PORT` | `587`               | The port to use for the SMTP server.             |
 | `SMTP_USERNAME` |                     | The username for the SMTP server.                |
 | `SMTP_PASSWORD` |                     | The password for the SMTP server.                |
+| `SMTP_SECURE` | `false`               | Use TLS when connecting to the server, typically for port 465. Defaults to false. [See nodemailer 'secure' for details](https://nodemailer.com/smtp/)  |
 | `MAIL_FROM_ADDRESS` | `hello@example.com` | The email address that emails will be sent from. |
 | `MAIL_FROM_NAME` | `Docmost`           | The name that emails will be sent from.          |
 


### PR DESCRIPTION
This addition really breaks the overall look of the page with its long line. A [manual line break](https://github.com/facebook/docusaurus/discussions/9085) with `<br/>` might be appropriate.

ref docmost/docmost#119