### PR TITLE
Added AWS_S3_FORCE_PATH_STYLE env variable for S3 configuration

### DIFF
--- a/docs/self-hosting/configuration/index.md
+++ b/docs/self-hosting/configuration/index.md
@@ -42,6 +42,7 @@ AWS_S3_SECRET_ACCESS_KEY=
 AWS_S3_REGION=
 AWS_S3_BUCKET=
 AWS_S3_ENDPOINT=
+AWS_S3_FORCE_PATH_STYLE=
 ```
 
 Being S3-compatible means Docmost can work with AWS S3, Backblaze, Wasabi, DigitalOcean Spaces, Minio, and other S3-compatible providers.

--- a/docs/self-hosting/environment-variables.md
+++ b/docs/self-hosting/environment-variables.md
@@ -46,6 +46,7 @@ To configure your application, set the following environment variables. These va
 | `AWS_S3_REGION`            |         | The region where your S3 bucket is located.      |
 | `AWS_S3_BUCKET`            |         | The name of your S3 bucket.                      |
 | `AWS_S3_ENDPOINT`          |         | The endpoint URL for your S3 service (optional). |
+| `AWS_S3_FORCE_PATH_STYLE`  | `true`  | Force the request to use path-style addressing (optional). |
 
 ## Email Configuration
 


### PR DESCRIPTION
Hello, 
While configuring docmost, I noticed that the documentation was missing the AWS_S3_FORCE_PATH_STYLE variable, which is useful for MinIO configurations, for example. This feature has been added to this [PR#181](https://github.com/docmost/docmost/pull/181). 

So I added it to the configuration and environment variables page. 

Thank you !