### PR TITLE
Official script to install Docker

### DIFF
--- a/docs/self-hosting/installation/index.md
+++ b/docs/self-hosting/installation/index.md
@@ -17,20 +17,7 @@ If you use Ubuntu, you can install Docker with the commands below:
   <summary>Click to see Ubuntu docker installation commands</summary>
 
 ```shell
-    # Add Docker's official GPG key:
-    sudo apt-get update -qqy
-    sudo apt-get install ca-certificates curl -qqy
-    sudo install -m 0755 -d /etc/apt/keyrings
-    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-    sudo chmod a+r /etc/apt/keyrings/docker.asc
-    
-    # Add the repository to Apt sources:
-    echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt-get update -qqy
-    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin -qqy
+    curl -fsSL https://get.docker.com | sh -
 ```
 
 </details>


### PR DESCRIPTION
Instead of showing the ugly commands, we can instead use official installer script which under the hood does the exact same.