### PR TITLE
Caddy as choice for reverse proxy

### DIFF
--- a/docs/self-hosting/installation/index.md
+++ b/docs/self-hosting/installation/index.md
@@ -143,6 +143,8 @@ Congratulations 🎉.
 
 :::warning[Reverse Proxy / WebSockets]
 If you are using a reverse proxy, make sure WebSockets is enabled. The real-time page editor depends on WebSockets to work.
+
+[Caddy](https://caddyserver.com/) is a great choice as a reverse proxy because it supports WebSocket connections out of the box. 
 :::
 
 If you encounter any issues, feel free to create an issue or discussion on the [GitHub repo](https://github.com/docmost/docmost).


### PR DESCRIPTION
I've used Caddy for reverse proxy, and it's works out of the box with Web Socket support. If you agree, we can mention that in the docs for those trying to choose reverse proxy.