### PR TITLE
Update page-permissions.md to clearly list compatible plans

### DIFF
--- a/docs/user-guide/pages/page-permissions.md
+++ b/docs/user-guide/pages/page-permissions.md
@@ -9,7 +9,7 @@ tags:
 Page permissions allow you to control who can view and edit individual pages within a space. By default, all pages in a space are accessible to every space member based on their space role. With page permissions, you can restrict specific pages so that only selected users and groups have access.
 
 :::note
-Page permissions is an enterprise feature. An active enterprise license is required.
+Page permissions is a commercial feature. An active Business or Enterprise license is required.
 :::
 
 ## Access Levels


### PR DESCRIPTION
Changed to more clearly match the [advertised plan structure by Docmost](https://docmost.com/pricing), since when I read the current wording, I took it to mean that only Enterprise plans have access to page permissions.